### PR TITLE
[feat/#39] redux-posts 모듈 생성, Firestore (redux활용) db연결해 메인화면 목록 뜨게하기 구현

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -31,14 +31,14 @@ const Header = () => {
                 </TabsWrapper>
                 <LinkWrapper>
                     <NewPostLink to={`postform`}>글쓰기</NewPostLink>
-                    {/* to={`detail/${id}`} */}
+                    {/* 유저 로그인상태? 마이페이지이동,이미지 : 로그인버튼 */}
                     <LoginLink to="log_in">로그인</LoginLink>
-                    <Link to="/">
+                    <Link to="mypage">
                         <UserImg />
                     </Link>
                 </LinkWrapper>
             </MainNav>
-        </HeaderWrapper> //
+        </HeaderWrapper>
     );
 };
 

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -34,6 +34,7 @@ const Header = () => {
                     {/* 유저 로그인상태? 마이페이지이동,이미지 : 로그인버튼 */}
                     <LoginLink to="log_in">로그인</LoginLink>
                     <Link to="mypage">
+                        {/*유저프로필이미지 (없으면 기본이미지인) 가져오기 */}
                         <UserImg />
                     </Link>
                 </LinkWrapper>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -76,9 +76,8 @@ const Tab = styled.li`
     height: 50px;
     border: 1px solid var(--subColor1);
     border-radius: 20px;
-    background-color: ${(props) =>
-        props.$isActive === props.children ? "var(--subColor1)" : "none"};
-    color: ${(props) => (props.$isActive === props.children ? "var(--mainColor)" : "none")};
+    background-color: ${(props) => (props.$isActive === props.id ? "var(--subColor1)" : "none")};
+    color: ${(props) => (props.$isActive === props.id ? "var(--mainColor)" : "none")};
 `;
 
 const LinkWrapper = styled.div`

--- a/src/components/main/RecommendListMain.jsx
+++ b/src/components/main/RecommendListMain.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import styled from "styled-components";
-import MainPostItem from "./MainPostItem";
+import MainPostItem from "./RecommendPostItem";
 import { dummyData } from "shared/postsDummyData";
 import { useDispatch, useSelector } from "react-redux";
 
-const Main = () => {
+const RecommendListMain = () => {
     // 홈 페이지의 메인 영역
     const activeCategory = useSelector((state) => state.category);
     // const filteredPosts = posts.filter(post)
@@ -22,9 +22,9 @@ const Main = () => {
     );
 };
 
-export default Main;
+export default RecommendListMain;
 
-const MainWrapper = styled.div`
+const MainWrapper = styled.main`
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/components/main/RecommendListMain.jsx
+++ b/src/components/main/RecommendListMain.jsx
@@ -1,14 +1,39 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import styled from "styled-components";
 import MainPostItem from "./RecommendPostItem";
 import { dummyData } from "shared/postsDummyData";
 import { useDispatch, useSelector } from "react-redux";
+import { db } from "database/firebase";
+import { collection, getDocs, query } from "firebase/firestore";
+import { setPost } from "store/modules/posts";
 
 const RecommendListMain = () => {
     // 홈 페이지의 메인 영역
+    // const [posts, setPosts] = useState([]);
+    const setPosts = useSelector((state) => state.posts);
     const activeCategory = useSelector((state) => state.category);
+    const dispatch = useDispatch();
     // const filteredPosts = posts.filter(post)
-    const filteredPosts = dummyData.filter((post) => post.category === activeCategory);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            // firestore db 가져오기
+            const q = query(collection(db, "posts"));
+            const querySnapshot = await getDocs(q);
+            console.log(querySnapshot);
+
+            const initialPosts = [];
+
+            querySnapshot.forEach((doc) => {
+                initialPosts.push({ id: doc.id, ...doc.data() });
+            });
+            // firestore에서 가져온 데이터를 redux 통해 전달
+            dispatch(setPost(initialPosts)); // modules폴더의 posts 임포트하기
+        };
+        fetchData();
+    }, []);
+    console.log(setPosts);
+    const filteredPosts = setPosts.filter((post) => post.category === activeCategory);
 
     return (
         <MainWrapper>

--- a/src/components/main/RecommendPostItem.jsx
+++ b/src/components/main/RecommendPostItem.jsx
@@ -1,12 +1,20 @@
 import React from "react";
 import styled from "styled-components";
 import thumbnailImg from "assets/thumbnailExImg.png";
+import { Navigate, useNavigate } from "react-router-dom";
 
 const RecommendPostItem = ({ post }) => {
-    const { writer, title, content, date } = post;
+    const { id, writer, title, content, date } = post;
+
+    const navigate = useNavigate();
+
+    const onPostItemClick = (id) => {
+        navigate(`detail/${id}`);
+    };
+
     return (
         <MainArticleWrapper>
-            <MainArticle>
+            <MainArticle onClick={() => onPostItemClick(id)}>
                 <ThumbImg />
                 <div>
                     <p>{title}</p>

--- a/src/components/main/RecommendPostItem.jsx
+++ b/src/components/main/RecommendPostItem.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import thumbnailImg from "assets/thumbnailExImg.png";
 
-const MainPostItem = ({ post }) => {
+const RecommendPostItem = ({ post }) => {
     const { writer, title, content, date } = post;
     return (
         <MainArticleWrapper>
@@ -18,7 +18,7 @@ const MainPostItem = ({ post }) => {
     );
 };
 
-export default MainPostItem;
+export default RecommendPostItem;
 
 const MainArticleWrapper = styled.li`
     list-style: none;

--- a/src/database/firebase.js
+++ b/src/database/firebase.js
@@ -1,5 +1,6 @@
 import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
 // https://firebase.google.com/docs/web/setup#available-libraries
 
 const firebaseConfig = {
@@ -20,3 +21,4 @@ const firebaseConfig = {
 // Initialize Firebase
 export const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
+export const db = getFirestore(app);

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Main from "components/main/RecommendListMain";
 import Layout from "components/layout/Layout";
 import Header from "components/Header/Header";
 import RecommendListMain from "components/main/RecommendListMain";

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,13 +1,14 @@
 import React from "react";
-import Main from "components/main/Main";
+import Main from "components/main/RecommendListMain";
 import Layout from "components/layout/Layout";
-import Header from "components/main/Header";
+import Header from "components/Header/Header";
+import RecommendListMain from "components/main/RecommendListMain";
 
 const Home = () => {
     return (
         <Layout>
             <Header />
-            <Main />
+            <RecommendListMain />
         </Layout>
     );
 };

--- a/src/store/config/configStore.js
+++ b/src/store/config/configStore.js
@@ -2,10 +2,12 @@ import { createStore } from "redux";
 import { combineReducers } from "redux";
 import userId from "store/modules/userId";
 import category from "store/modules/category";
+import posts from "store/modules/posts";
 
 const rootReducer = combineReducers({
     userId,
     category,
+    posts,
 });
 const store = createStore(rootReducer);
 

--- a/src/store/modules/posts.js
+++ b/src/store/modules/posts.js
@@ -1,0 +1,57 @@
+import { dummyData } from "shared/postsDummyData";
+
+const SET_POST = "posts / SET_POST";
+const ADD_POST = "posts/ADD_POST";
+const EDIT_POST = "posts/EDIT_POST";
+const DELETE_POST = "posts/DELETE_POST";
+
+export const setPost = (payload) => {
+    return { type: SET_POST, payload };
+};
+export const addPost = (payload) => {
+    return { type: ADD_POST, payload };
+};
+export const editPost = (payload) => {
+    return { type: EDIT_POST, payload };
+};
+export const deletePost = (payload) => {
+    return { type: DELETE_POST, payload };
+};
+
+const initialState = [
+    // {
+    //     id: "0",
+    //     category: "클래식및재즈",
+    //     nickname: "보라돌이",
+    //     title: "Autumn Leaves 추천해요",
+    //     content: "재즈 명곡 들어보세요!",
+    //     videoSrc: "https://www.youtube.com/watch?v=fKIqKvSKJfc",
+    // },
+];
+
+// 리듀서
+const posts = (state = initialState, action) => {
+    switch (action.type) {
+        case SET_POST: // 이게 맞는 지 잘 모르겠어요
+            const setPosts = action.payload;
+            return setPosts;
+        case ADD_POST:
+            const newPost = action.payload;
+            return [newPost, ...state];
+        case EDIT_POST:
+            const { id, editedContent } = action.payload;
+            return state.map((post) => {
+                if (post.id === id) {
+                    return { ...post, content: editedContent };
+                }
+                return post;
+            });
+        case DELETE_POST:
+            const postId = action.payload;
+            return state.fillter((post) => post.id !== postId);
+        default:
+            return state;
+    }
+};
+
+export default posts;


### PR DESCRIPTION
## 📌 관련 이슈
  closed #39

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [ ] 이걸 계속 복사해서 사용해주세요!

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
[[move] Header 원위치 폴더로 이동
redux-posts 모듈 생성(set add delete edit 타입),
파일 이름 변경 및 이동
홈페이지 에서 -> 글클릭시 상세페이지 이동, 프로필이미지클릭시 마이페이지 이동 구현 (link)
Firestore (redux활용) db연결해 메인화면 목록 뜨게하기 구현
```
##  TroubleShotting
<!-- TroubleShotting이 있었다면 이야기 해주세요! -->
```
Firestore (redux활용) db연결해 메인화면 목록 뜨게하기 구현
에서 막혔는데 useState로는 되었지만 redux를 활용하니 문제 발생
-> configstore에 모듈 추가 안해서 생긴 문제였습니다 ... ㅠㅠ 
해리님 명환님 해결해주셔서 감사합니다..ㅎㅎ
```
## 📸 스크린샷(선택)
```
|기능|스크린샷|
<!-- 기능을 gif로 만들어서 올려주세요 -->
[GIF]<img src = "" width="250">|
```
## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
